### PR TITLE
Fix option names

### DIFF
--- a/scripts/ton
+++ b/scripts/ton
@@ -12,9 +12,9 @@ get_tmux_option() {
   fi
 }
 
-OPEN_STRATEGY="$(get_tmux_option "open-strategy" ":e")"
-MENU_STYLE="$(get_tmux_option "menu-style" "")"
-MENU_SELECTED_STYLE="$(get_tmux_option "menu-selected-style")"
+OPEN_STRATEGY="$(get_tmux_option "ton-open-strategy" ":e")"
+MENU_STYLE="$(get_tmux_option "ton-menu-style" "")"
+MENU_SELECTED_STYLE="$(get_tmux_option "ton-menu-selected-style")"
 PRIORITIZE_WINDOW="$(get_tmux_option "ton-prioritize-window")"
 
 if [ -n "$MENU_STYLE" ]; then


### PR DESCRIPTION
The documentation says that the configuration options should be prefixed with `@ton-...`, but the script was referencing `open-strategy`, `menu-style` and `menu-selected-style` without the prefix.
This caused the plugin to ignore any user options that were properly prefixed.

> |Config |Description   | Example
> |---    |---           |---
> |`set -g @ton-open-strategy ":e"` | Command for opening a file | `:e` or `:tabnew`
> |`set -g @ton-menu-style` | Set style of display-menu for picking a pane | See `man tmux` STYLES
> |`set -g @ton-menu-selected-style` | Set style of display-menu selection for picking a pane | See `man tmux` STYLES
> |`set -g @ton-prioritize-window true` | If true and nvim exists in current window, opens directly in that instance. If false, prompts for a selection | `true` or `false`

