### PR TITLE
fix(scripts): handle end-of-options marker in ton script

### DIFF
--- a/scripts/ton
+++ b/scripts/ton
@@ -24,6 +24,11 @@ if [ -n "$MENU_SELECTED_STYLE" ]; then
   tmux_menu_H="-H $MENU_SELECTED_STYLE"
 fi
 
+# Check if the first argument is the end-of-options marker
+if [ "$1" = "--" ]; then
+    shift # Remove the '--' argument from the list
+fi
+
 # Check pipe from stdin or parameter
 FPATH=${STDIN:-$1}
 if [ "$1" ]; then


### PR DESCRIPTION
### Summary

This PR adds logic to check if the first argument is the end-of-options marker (`--`) and removes it from the argument list if present.  
This ensures that arguments are correctly handled when `--` is used, preventing it from being misinterpreted as a file path or other parameter.

### Details

-   Detects if the first argument equals `--`
    
-   Shifts it from the argument list before processing
    
-   Improves compatibility with tools and scripts that use `--` to signal the end of options
    

### Motivation

This change is required for compatibility with [tmux-open](https://github.com/tmux-plugins/tmux-open), which invokes the `open-editor` command [using](https://github.com/tmux-plugins/tmux-open/blob/763d0a852e6703ce0f5090a508330012a7e6788e/open.tmux#L87) a `--` argument.